### PR TITLE
use consistent prefixes per 8407bis

### DIFF
--- a/examples/example-acl.yang
+++ b/examples/example-acl.yang
@@ -1,10 +1,10 @@
 module example-acl {
   yang-version 1.1;
   namespace "urn:example:acl";
-  prefix "acl";
+  prefix "ex-acl";
 
   import example-application {
-    prefix "app";
+    prefix "ex-app";
   }
 
   import ietf-inet-types {
@@ -31,7 +31,8 @@ module example-acl {
         choice applications {
           leaf-list application {
             type leafref {
-              path "/app:applications/app:application/app:name";
+              path "/ex-app:applications/ex-app:application"
+                 + "/ex-app:name";
             }
           }
         }

--- a/examples/example-application.yang
+++ b/examples/example-application.yang
@@ -1,7 +1,7 @@
 module example-application {
   yang-version 1.1;
   namespace "urn:example:application";
-  prefix "app";
+  prefix "ex-app";
 
   import ietf-inet-types {
     prefix "inet";

--- a/examples/example-bgp.yang
+++ b/examples/example-bgp.yang
@@ -1,7 +1,7 @@
 module example-bgp {
   yang-version 1.1;
   namespace "urn:example:bgp";
-  prefix exbgp;
+  prefix ex-bgp;
 
   import ietf-inet-types {
     prefix inet;


### PR DESCRIPTION
   For convenience, prefix values of example modules MAY be prefixed
   with "ex" or similar patterns.  In doing so, readers of example
   modules or tree diagrams that mix both example and standard modules
   can easily identify example parts.

Other parts of the doc will be impacted by this change